### PR TITLE
feat: ability to specify ALPN (for http2 and ssh-over-tls)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ before:
     - go mod download
     - go generate ./...
 builds:
-  - main: ./cmd/sclient/main.go
+  - main: ./cmd/sclient/
     env:
       - CGO_ENABLED=0
     goos:

--- a/README.md
+++ b/README.md
@@ -70,16 +70,28 @@ sclient [flags] <remote> <local>
 ```
 
 - flags
-  - -s, --silent less verbose logging
-  - -k, --insecure ignore invalid TLS (SSL/HTTPS) certificates
-  - --servername <string> spoof SNI (to disable use IP as &lt;remote&gt; and do
+  - `-s`, `--silent` less verbose logging
+  - `-k`, `--insecure` ignore invalid TLS (SSL/HTTPS) certificates
+  - `--servername <domain>` spoof SNI (to disable use IP as &lt;remote&gt; and do
     not use this option)
+  - `--alpn <protocol-list>`
 - remote
   - must have servername (i.e. example.com)
   - port is optional (default is 443)
 - local
   - address is optional (default is localhost)
   - must have port (i.e. 3000)
+
+  -alpn string
+    	acceptable protocols, ex: 'h2,http/1.1' 'http/1.1' (default) 'ssh' (default "http/1.1")
+  -insecure
+    	ignore bad TLS/SSL/HTTPS certificates
+  -k	alias for --insecure
+  -s	alias of --silent
+  -servername string
+    	specify a servername different from <remote> (to disable SNI use an IP as <remote> and do use this option)
+  -silent
+    	less verbose output
 
 # Examples
 

--- a/cmd/sclient/main.go
+++ b/cmd/sclient/main.go
@@ -50,7 +50,7 @@ func main() {
 	flag.Usage = usage
 	insecure := flag.Bool("k", false, "alias for --insecure")
 	silent := flag.Bool("s", false, "alias of --silent")
-	servername := flag.String("servername", "", "specify a servername different from <remote> (to disable SNI use an IP as <remote> and do use this option)")
+	servername := flag.String("servername", "", "specify a servername different from <remote> (to disable SNI use an IP as <remote> and do not use this option)")
 	flag.BoolVar(insecure, "insecure", false, "ignore bad TLS/SSL/HTTPS certificates")
 	flag.BoolVar(silent, "silent", false, "less verbose output")
 	flag.Parse()

--- a/sclient.go
+++ b/sclient.go
@@ -17,6 +17,7 @@ type Tunnel struct {
 	LocalAddress       string
 	LocalPort          int
 	InsecureSkipVerify bool
+	NextProtos         []string
 	ServerName         string
 	Silent             bool
 }
@@ -29,6 +30,7 @@ func (t *Tunnel) DialAndListen() error {
 		&tls.Config{
 			ServerName:         t.ServerName,
 			InsecureSkipVerify: t.InsecureSkipVerify,
+			NextProtos:         t.NextProtos,
 		})
 
 	if err != nil {


### PR DESCRIPTION
Comma-separated list.
```text
--alpn 'ssh'
--alpn 'h2,http/1.1'
```

Goes into `NextProtos` list in `tls.Config`.