### PR TITLE
ref!: supply a full *tls.Config for each connection

### DIFF
--- a/cmd/sclient/main.go
+++ b/cmd/sclient/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
@@ -79,12 +80,16 @@ func main() {
 	}
 
 	sclient := &sclient.Tunnel{
-		RemotePort:         443,
-		LocalAddress:       "localhost",
-		InsecureSkipVerify: insecure,
-		ServerName:         servername,
-		Silent:             silent,
-		NextProtos:         alpns,
+		RemotePort:   443,
+		LocalAddress: "localhost",
+		Silent:       silent,
+		GetTLSConfig: func() *tls.Config {
+			return &tls.Config{
+				ServerName:         servername,
+				NextProtos:         alpns,
+				InsecureSkipVerify: insecure,
+			}
+		},
 	}
 
 	remote := strings.Split(remotestr, ":")


### PR DESCRIPTION
Rather than having the sclient Config to include a limited set of tls.Config properties and extending them for new support, we will construct a new tls.Config from a give template function as needed.

This is a breaking change to the library, but not a philosophical or difficult change - so it's for a v2 rather than a rename.

It does not break the CLI.