### PR TITLE
fix(alpn): use alpn both for test and real connection

### DIFF
--- a/cmd/sclient/main.go
+++ b/cmd/sclient/main.go
@@ -68,9 +68,9 @@ func main() {
 	localstr := flag.Arg(1)
 
 	i := flag.NArg()
-	if 2 != i {
+	if i != 2 {
 		// We may omit the second argument if we're going straight to stdin
-		if stat, _ := os.Stdin.Stat(); 1 == i && (stat.Mode()&os.ModeCharDevice) == 0 {
+		if stat, _ := os.Stdin.Stat(); i == 1 && (stat.Mode()&os.ModeCharDevice) == 0 {
 			localstr = "|"
 		} else {
 			usage()
@@ -89,20 +89,20 @@ func main() {
 
 	remote := strings.Split(remotestr, ":")
 	//remoteAddr, remotePort, err := net.SplitHostPort(remotestr)
-	if 2 == len(remote) {
+	if len(remote) == 2 {
 		rport, err := strconv.Atoi(remote[1])
 		if nil != err {
 			usage()
 			os.Exit(0)
 		}
 		sclient.RemotePort = rport
-	} else if 1 != len(remote) {
+	} else if len(remote) != 1 {
 		usage()
 		os.Exit(0)
 	}
 	sclient.RemoteAddress = remote[0]
 
-	if "-" == localstr || "|" == localstr {
+	if localstr == "-" || localstr == "|" {
 		// User may specify stdin/stdout instead of net
 		sclient.LocalAddress = localstr
 		sclient.LocalPort = -1
@@ -110,7 +110,7 @@ func main() {
 		// Test that argument is a local address
 		local := strings.Split(localstr, ":")
 
-		if 1 == len(local) {
+		if len(local) == 1 {
 			lport, err := strconv.Atoi(local[0])
 			if nil != err {
 				usage()
@@ -144,9 +144,8 @@ func parseOptionList(optionList string) []string {
 		return nil
 	}
 
-	options := []string{}
 	optionList = strings.ReplaceAll(optionList, ",", " ")
-	options = strings.Fields(optionList)
+	options := strings.Fields(optionList)
 
 	return options
 }

--- a/sclient.go
+++ b/sclient.go
@@ -29,8 +29,8 @@ func (t *Tunnel) DialAndListen() error {
 	conn, err := tls.Dial("tcp", remote,
 		&tls.Config{
 			ServerName:         t.ServerName,
-			InsecureSkipVerify: t.InsecureSkipVerify,
 			NextProtos:         t.NextProtos,
+			InsecureSkipVerify: t.InsecureSkipVerify,
 		})
 
 	if err != nil {
@@ -145,6 +145,7 @@ func (t *Tunnel) handleConnection(remote string, conn netReadWriteCloser) {
 	sclient, err := tls.Dial("tcp", remote,
 		&tls.Config{
 			ServerName:         t.ServerName,
+			NextProtos:         t.NextProtos,
 			InsecureSkipVerify: t.InsecureSkipVerify,
 		})
 

--- a/sclient.go
+++ b/sclient.go
@@ -36,14 +36,14 @@ func (t *Tunnel) DialAndListen() error {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[warn] '%s' may not be accepting connections: %s\n", remote, err)
 	} else {
-		conn.Close()
+		_ = conn.Close()
 	}
 
 	// use stdin/stdout
-	if "-" == t.LocalAddress || "|" == t.LocalAddress {
+	if t.LocalAddress == "-" || t.LocalAddress == "|" {
 		var name string
 		network := "stdio"
-		if "|" == t.LocalAddress {
+		if t.LocalAddress == "|" {
 			name = "pipe"
 		} else {
 			name = "stdin"
@@ -61,7 +61,7 @@ func (t *Tunnel) DialAndListen() error {
 	}
 
 	if !t.Silent {
-		fmt.Fprintf(os.Stdout, "[listening] %s:%d <= %s:%d\n",
+		_, _ = fmt.Fprintf(os.Stdout, "[listening] %s:%d <= %s:%d\n",
 			t.RemoteAddress, t.RemotePort, t.LocalAddress, t.LocalPort)
 	}
 
@@ -117,11 +117,11 @@ func pipe(r netReadWriteCloser, w netReadWriteCloser, t string) {
 			if io.EOF != err {
 				fmt.Fprintf(os.Stderr, "[read error] (%s:%d) %s\n", t, count, err)
 			}
-			r.Close()
+			_ = r.Close()
 			//w.Close()
 			done = true
 		}
-		if 0 == count {
+		if count == 0 {
 			break
 		}
 		_, err = w.Write(buffer[:count])
@@ -131,7 +131,7 @@ func pipe(r netReadWriteCloser, w netReadWriteCloser, t string) {
 				fmt.Fprintf(os.Stderr, "[write error] (%s) %s\n", t, err)
 			}
 			// TODO handle error closing?
-			r.Close()
+			_ = r.Close()
 			//w.Close()
 			done = true
 		}
@@ -151,16 +151,16 @@ func (t *Tunnel) handleConnection(remote string, conn netReadWriteCloser) {
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[error] (remote) %s\n", err)
-		conn.Close()
+		_ = conn.Close()
 		return
 	}
 
 	if !t.Silent {
-		if "stdio" == conn.RemoteAddr().Network() {
-			fmt.Fprintf(os.Stdout, "(connected to %s:%d and reading from %s)\n",
+		if conn.RemoteAddr().Network() == "stdio" {
+			_, _ = fmt.Fprintf(os.Stdout, "(connected to %s:%d and reading from %s)\n",
 				t.RemoteAddress, t.RemotePort, conn.RemoteAddr().String())
 		} else {
-			fmt.Fprintf(os.Stdout, "[connect] %s => %s:%d\n",
+			_, _ = fmt.Fprintf(os.Stdout, "[connect] %s => %s:%d\n",
 				strings.Replace(conn.RemoteAddr().String(), "[::1]:", "localhost:", 1), t.RemoteAddress, t.RemotePort)
 		}
 	}


### PR DESCRIPTION
Apparently the alpn option has never worked properly. This fixes that.

In the future we may want to default to http/1.1.